### PR TITLE
decreased padding to display close button in `#selectionBox` on Chromium

### DIFF
--- a/chrome_plugin/css/style.css
+++ b/chrome_plugin/css/style.css
@@ -374,7 +374,7 @@ mark {
 	z-index: 1000;
 	height: 50px;
 	float:right;
-	padding: 0 20%;
+	padding: 0 15%;
 	font-family: arial;
 	color: white;
 	vertical-align: middle;


### PR DESCRIPTION
The Close button in the selection box is not displaying properly in chromium (Version 43.0.2357.125 (64-bit)) on my laptop. The `#backButton` div overlaps with the `#deleteCart` div when the padding on `#backButton` is set to 20%. A smaller padding fixes the issue for me.
